### PR TITLE
Add PiMarket – P2P Pi Marketplace by @mnooogo1

### DIFF
--- a/pimarket.md
+++ b/pimarket.md
@@ -1,0 +1,35 @@
+# PiMarket – P2P Marketplace Powered by Pi 💱
+
+**Live demo:** [https://playforall.online/pimarket](https://playforall.online/pimarket)  
+**GitHub repo:** [https://github.com/Mnooogo/pimarket](https://github.com/Mnooogo/pimarket)  
+**Pi Username:** @mnooogo1  
+**Contact:** mnooogopi@devcodeapp.site  
+**License:** PiOS  
+
+---
+
+## 🚀 How Pi is Used:
+
+PiMarket is built entirely around **Pi as the primary currency**.  
+Every product listing is priced in π, with real-time conversion from local currency via the **Bitget API**.  
+Future updates will include **direct Pi Wallet payments** and an **escrow system** for added security.  
+The system requires **no fiat, no banks, no intermediaries** – just **Pi and people**.
+
+---
+
+## 🌍 Why This Project Matters:
+
+PiMarket addresses real-world needs in **emerging regions**, where:
+- access to stable financial platforms is limited,  
+- fiat currencies are often unstable or unavailable,  
+- but **mobile devices and Pi accounts are widely used**.
+
+This creates an opportunity to **unlock real economic value** using Pi –  
+enabling local trade of goods and services **without middlemen, without fiat**.
+
+The platform is:
+- 💻 **100% open source (PiOS)**,  
+- 📱 mobile-ready and lightweight,  
+- 🚫 completely independent of app stores and traditional payment processors.
+
+---


### PR DESCRIPTION
Submitting PiMarket as a public open source P2P marketplace built on PiOS. Enables local trade using Pi only. Full demo and repo available.